### PR TITLE
fix(text_editor): correct hash calculation for multi-line ranges

### DIFF
--- a/src/mcp_text_editor/text_editor.py
+++ b/src/mcp_text_editor/text_editor.py
@@ -145,12 +145,14 @@ class TextEditor:
             for range_spec in file_range.ranges:
                 start = max(1, range_spec.start) - 1
                 end_value = range_spec.end
+                # Calculate actual end for slicing (0-based exclusive)
                 end = (
                     min(total_lines, end_value)
                     if end_value is not None
                     else total_lines
                 )
-                end_1based = end_value if end_value is not None else total_lines
+                # end_1based should reflect the actual sliced range, not the input value
+                end_1based = end
 
                 if start >= total_lines:
                     empty_content = ""


### PR DESCRIPTION
## Summary
- Fix hash calculation bug in `read_multiple_ranges` that caused "Content hash mismatch" errors for multi-line operations
- Add regression tests to prevent future issues

## Problem
The `read_multiple_ranges` function returned the input `end` value directly instead of the actual sliced range, causing hash validation failures when the returned range was used for subsequent edit operations.

Example with a 5-line file requesting `end=10`:
- Actual slice: `lines[0:5]` (up to line 5)
- Returned `end`: 10 (input value) ← **Bug**
- Hash was calculated for lines 1-5, but `end` claimed lines 1-10

## Solution
Changed `end_1based` to reflect the actual sliced range instead of the input value.

```python
# Before (buggy)
end_1based = end_value if end_value is not None else total_lines

# After (fixed)
end_1based = end  # Reflects actual sliced range
```

## Testing
- All 165 existing tests pass
- Added 2 regression tests:
  - `test_read_multiple_ranges_hash_consistency`: Verifies hash from read can be used for edit
  - `test_read_multiple_ranges_end_exceeds_file_length`: Verifies end value clamping

Closes #12