### PR TITLE
fix: replace fcntl with portalocker for Windows compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 dependencies = [
     "mcp>=1.25.0",
     "chardet>=5.2.0",
+    "portalocker>=3.2.0",
 ]
 requires-python = ">=3.13"
 readme = "README.md"

--- a/src/mcp_text_editor/utils.py
+++ b/src/mcp_text_editor/utils.py
@@ -1,11 +1,12 @@
 """Security utilities for the MCP Text Editor."""
 
-import fcntl
 import hmac
 import os
 import pathlib
 from contextlib import contextmanager
 from typing import Generator, Optional
+
+import portalocker
 
 
 def _contains_traversal_patterns(s: str) -> bool:
@@ -111,9 +112,9 @@ def locked_file(file_path: str, mode: str = "r+") -> Generator:
         IOError: If file operations fail
     """
     if "r" in mode and "+" not in mode and "w" not in mode and "a" not in mode:
-        lock_type = fcntl.LOCK_SH
+        lock_type = portalocker.LOCK_SH
     else:
-        lock_type = fcntl.LOCK_EX
+        lock_type = portalocker.LOCK_EX
     file_obj = None
     try:
         # When opening for write/create, ensure parent directory exists
@@ -128,12 +129,12 @@ def locked_file(file_path: str, mode: str = "r+") -> Generator:
         ):
             raise ValueError("Invalid path: path points to a directory")
         file_obj = open(file_path, mode, encoding="utf-8")
-        fcntl.flock(file_obj.fileno(), lock_type)
+        portalocker.lock(file_obj, lock_type)
         yield file_obj
     finally:
         if file_obj:
             try:
-                fcntl.flock(file_obj.fileno(), fcntl.LOCK_UN)
+                portalocker.unlock(file_obj)
             except (OSError, ValueError):
                 pass
             try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,105 @@
+"""Tests for utility helpers."""
+
+import os
+import pathlib
+import subprocess
+import sys
+
+from mcp_text_editor import utils
+
+
+def test_locked_file_uses_shared_lock_for_read(monkeypatch, tmp_path):
+    """Read mode should acquire a shared lock and release it on exit."""
+    file_path = tmp_path / "shared.txt"
+    file_path.write_text("hello\n", encoding="utf-8")
+    lock_calls = []
+    unlock_calls = []
+
+    monkeypatch.setattr(
+        utils.portalocker,
+        "lock",
+        lambda file_obj, lock_type: lock_calls.append(lock_type),
+    )
+    monkeypatch.setattr(
+        utils.portalocker,
+        "unlock",
+        lambda file_obj: unlock_calls.append(file_obj.name),
+    )
+
+    with utils.locked_file(str(file_path), "r") as file_obj:
+        assert file_obj.read() == "hello\n"
+
+    assert lock_calls == [utils.portalocker.LOCK_SH]
+    assert unlock_calls == [str(file_path)]
+
+
+def test_locked_file_uses_exclusive_lock_for_write(monkeypatch, tmp_path):
+    """Write mode should create parent directories and use an exclusive lock."""
+    file_path = tmp_path / "nested" / "exclusive.txt"
+    lock_calls = []
+    unlock_calls = []
+
+    monkeypatch.setattr(
+        utils.portalocker,
+        "lock",
+        lambda file_obj, lock_type: lock_calls.append(lock_type),
+    )
+    monkeypatch.setattr(
+        utils.portalocker,
+        "unlock",
+        lambda file_obj: unlock_calls.append(file_obj.name),
+    )
+
+    with utils.locked_file(str(file_path), "w") as file_obj:
+        file_obj.write("created\n")
+
+    assert file_path.read_text(encoding="utf-8") == "created\n"
+    assert lock_calls == [utils.portalocker.LOCK_EX]
+    assert unlock_calls == [str(file_path)]
+
+
+def test_package_import_succeeds_without_fcntl():
+    """Import should not crash when the package itself no longer imports fcntl."""
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    src_path = str(repo_root / "src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not existing_pythonpath
+        else os.pathsep.join([src_path, existing_pythonpath])
+    )
+    code = """
+import builtins
+import importlib
+import sys
+import types
+
+fake_portalocker = types.ModuleType("portalocker")
+fake_portalocker.LOCK_SH = 1
+fake_portalocker.LOCK_EX = 2
+fake_portalocker.lock = lambda file_obj, lock_type: None
+fake_portalocker.unlock = lambda file_obj: None
+sys.modules["portalocker"] = fake_portalocker
+
+orig_import = builtins.__import__
+
+def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "fcntl":
+        raise ImportError("blocked for test")
+    return orig_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = guarded_import
+importlib.import_module("mcp_text_editor")
+print("ok")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"

--- a/uv.lock
+++ b/uv.lock
@@ -469,6 +469,7 @@ source = { editable = "." }
 dependencies = [
     { name = "chardet" },
     { name = "mcp" },
+    { name = "portalocker" },
 ]
 
 [package.optional-dependencies]
@@ -494,6 +495,7 @@ requires-dist = [
     { name = "isort", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "mcp", specifier = ">=1.25.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.0" },
+    { name = "portalocker", specifier = ">=3.2.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.3.0" },
@@ -583,6 +585,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace POSIX-only `fcntl` with cross-platform `portalocker` for file locking
- Windows users can now import and use mcp-text-editor without crash
- Added regression tests for lock type selection and import boundary

## Test plan
- [x] `uv run pytest` — 168 tests pass
- [x] `uv run ruff check src tests` — clean
- [x] `uv run mypy src tests` — clean
- [ ] Verify on actual Windows environment

Closes #18

🤖 Generated with [Paperclip](https://paperclip.ing) + [Claude Code](https://claude.com/claude-code)