### PR TITLE
fix: remove duplicate content split

### DIFF
--- a/src/mcp_text_editor/text_editor.py
+++ b/src/mcp_text_editor/text_editor.py
@@ -308,7 +308,6 @@ class TextEditor:
                     )
                 else:
                     lines = current_file_content.splitlines(keepends=True)
-                    lines = current_file_content.splitlines(keepends=True)
 
             # Convert patches to EditPatch objects
             patch_objects = [EditPatch.model_validate(p) for p in patches]


### PR DESCRIPTION
## Summary

- remove the duplicated `splitlines(keepends=True)` assignment in `TextEditor.edit_file_contents`
- preserve behavior while avoiding the redundant full-content split

## Verification

- `uv run pytest -q` — 168 passed
- `make check` — formatting, lint, and type checking passed

Closes #29
