### PR TITLE
ci: install dependencies from lockfile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install uv
 
-      - name: Install dev/test dependencies
-        run: |
-          pip install -e ".[dev]"
-          pip install -e ".[test]"
+      - name: Install locked dependencies
+        run: uv sync --all-extras --frozen
 
       - name: Run tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest --cov --cov-report=xml
+          uv run pytest --cov --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install uv
 
-      - name: Install dev/test dependencies
-        run: |
-          pip install -e ".[dev]"
-          pip install -e ".[test]"
+      - name: Install locked dependencies
+        run: uv sync --all-extras --frozen
 
       - name: Run lint and typecheck
         run: |


### PR DESCRIPTION
## Summary

- install CI dependencies with `uv sync --all-extras --frozen`
- make test and release validation use the committed `uv.lock`
- prevent an unreviewed MCP SDK upgrade from changing type behavior during CI

## Verification

- `uv sync --all-extras --frozen`
- `make check`
- `uv run pytest -q` — 168 passed

This fixes the current CI drift where plain `pip install` resolves MCP 2.2.0 while the repository lockfile and implementation use MCP 1.25.0.
