### PR TITLE
fix: reject unknown patch fields

### DIFF
--- a/src/mcp_text_editor/models.py
+++ b/src/mcp_text_editor/models.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class GetTextFileContentsRequest(BaseModel):
@@ -24,6 +24,8 @@ class GetTextFileContentsResponse(BaseModel):
 
 class EditPatch(BaseModel):
     """Model for a single edit patch operation."""
+
+    model_config = ConfigDict(extra="forbid")
 
     start: int = Field(1, description="Starting line for edit")
     end: Optional[int] = Field(None, description="Ending line for edit")

--- a/src/mcp_text_editor/text_editor.py
+++ b/src/mcp_text_editor/text_editor.py
@@ -254,6 +254,15 @@ class TextEditor:
         """
         self._validate_file_path(file_path)
         try:
+            # Reject unknown mapping fields before creating directories or touching files.
+            allowed_patch_fields = set(EditPatch.model_fields)
+            for raw_patch in patches:
+                if isinstance(raw_patch, dict):
+                    unknown_fields = set(raw_patch) - allowed_patch_fields
+                    if unknown_fields:
+                        unknown = ", ".join(sorted(unknown_fields))
+                        raise ValueError(f"Unknown patch field(s): {unknown}")
+
             if not os.path.exists(file_path):
                 if expected_file_hash not in ["", None]:  # Allow null hash
                     return self.create_error_response(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -70,6 +70,17 @@ def test_edit_patch():
     assert patch.contents == "new content"
     assert patch.range_hash == "somehash"
 
+    # Reject stale field names instead of silently applying default whole-file range
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        EditPatch.model_validate(
+            {
+                "line_start": 5,
+                "line_end": 10,
+                "contents": "new content",
+                "range_hash": "somehash",
+            }
+        )
+
     # Test validation error - missing required field
     with pytest.raises(ValidationError):
         EditPatch()

--- a/tests/test_text_editor.py
+++ b/tests/test_text_editor.py
@@ -33,6 +33,21 @@ async def test_edit_file_with_edit_patch_object(editor, tmp_path):
     assert test_file.read_text() == "new line\nline2\nline3\n"
 
 
+@pytest.mark.asyncio
+async def test_invalid_patch_does_not_create_parent_directory(editor, tmp_path):
+    """Validate patches before creating a missing file's parent directory."""
+    target = tmp_path / "missing" / "file.txt"
+
+    result = await editor.edit_file_contents(
+        str(target),
+        "",
+        [{"line_start": 1, "contents": "unexpected\n", "range_hash": ""}],
+    )
+
+    assert result["result"] == "error"
+    assert not target.parent.exists()
+
+
 @pytest.fixture
 def test_file(tmp_path):
     """Create a temporary test file."""
@@ -381,7 +396,7 @@ async def test_directory_creation_failure(editor, tmp_path):
     result = await editor.edit_file_contents(
         str(test_file),
         "",  # New file
-        [{"line_start": 1, "contents": "test content\n", "range_hash": None}],
+        [{"start": 1, "contents": "test content\n", "range_hash": None}],
     )
 
     assert result["result"] == "error"
@@ -402,7 +417,7 @@ async def test_invalid_encoding_file_operations(editor, tmp_path):
     result = await editor.edit_file_contents(
         str(test_file),
         "",  # hash doesn't matter as it will fail before hash check
-        [{"line_start": 1, "contents": "new content\n", "range_hash": None}],
+        [{"start": 1, "contents": "new content\n", "range_hash": None}],
         encoding="utf-8",
     )
 
@@ -617,7 +632,7 @@ async def test_create_file_directory_creation_failure(editor, tmp_path, monkeypa
         "",  # Empty hash for new file
         [
             {
-                "line_start": 1,
+                "start": 1,
                 "contents": "test content\n",
             }
         ],
@@ -646,7 +661,7 @@ async def test_io_error_handling(editor, tmp_path, monkeypatch):
     result = await editor.edit_file_contents(
         str(test_file),
         "",
-        [{"line_start": 1, "contents": "new content\n"}],
+        [{"start": 1, "contents": "new content\n"}],
     )
 
     assert result["result"] == "error"
@@ -667,7 +682,7 @@ async def test_exception_handling(editor, tmp_path, monkeypatch):
     result = await editor.edit_file_contents(
         str(test_file),
         "",
-        [{"line_start": 1, "contents": "new content\n"}],
+        [{"start": 1, "contents": "new content\n"}],
     )
 
     assert result["result"] == "error"

--- a/tests/test_text_editor.py
+++ b/tests/test_text_editor.py
@@ -333,7 +333,7 @@ async def test_empty_content_handling(editor, tmp_path):
         str(test_file),
         "",  # No hash for empty file
         [
-            {"line_start": 1, "contents": "New content\n", "range_hash": ""}
+            {"start": 1, "contents": "New content\n", "range_hash": ""}
         ],  # Empty range_hash for new files
     )
 


### PR DESCRIPTION
## Summary

- reject unknown `EditPatch` fields instead of silently applying defaults
- prevent stale `line_start` / `line_end` payloads from becoming whole-file replacements
- preserve valid `start` / `end` patch behavior

## Verification

- RED: regression test failed because unknown fields were accepted
- GREEN: `uv run pytest -q` — 168 passed
- `make check` — formatting, lint, and type checking passed

Closes #26
