### PR TITLE
fix: start server without nested event loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ COPY --from=uv --chown=app:app /app/src /app/src
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Run mcp server
-ENTRYPOINT ["python", "src/mcp_text_editor/server.py"]
+ENTRYPOINT ["mcp-text-editor"]

--- a/src/mcp_text_editor/__init__.py
+++ b/src/mcp_text_editor/__init__.py
@@ -1,7 +1,5 @@
 """MCP Text Editor Server package."""
 
-import asyncio
-
 from .server import main
 from .text_editor import TextEditor
 
@@ -11,4 +9,4 @@ _text_editor = TextEditor()
 
 def run() -> None:
     """Run the MCP Text Editor Server."""
-    asyncio.run(main())
+    main()

--- a/src/mcp_text_editor/server.py
+++ b/src/mcp_text_editor/server.py
@@ -105,13 +105,11 @@ async def insert_text_file_contents(
     )
 
 
-async def main() -> None:
+def main() -> None:
     """Main entry point for the MCP text editor server."""
     logger.info(f"Starting MCP text editor server v{__version__}")
-    await app.run()  # type: ignore[func-returns-value]
+    app.run()
 
 
 if __name__ == "__main__":
-    import asyncio
-
-    asyncio.run(main())
+    main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,8 @@
 """Tests for the MCP Text Editor Server."""
 
+import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -18,6 +21,35 @@ from mcp_text_editor.server import (
     patch_file_handler,
 )
 from mcp_text_editor.text_editor import TextEditor
+
+
+def test_console_script_handles_initialize_request():
+    """Test the installed console script with a real MCP initialize request."""
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "pytest", "version": "1.0.0"},
+        },
+    }
+
+    result = subprocess.run(
+        [str(Path(sys.executable).with_name("mcp-text-editor"))],
+        input=json.dumps(request) + "\n",
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    response = json.loads(result.stdout)
+    assert response["jsonrpc"] == "2.0"
+    assert response["id"] == 1
+    assert "result" in response
 
 
 @pytest.fixture
@@ -139,19 +171,17 @@ async def test_insert_text_file_contents(tmp_path, editor):
     assert Path(test_file).read_text().rstrip() == "before\ninserted\nafter"
 
 
-@pytest.mark.asyncio
-async def test_main_stdio_server_error(mocker: MockerFixture):
+def test_main_stdio_server_error(mocker: MockerFixture):
     """Test main function with stdio_server error."""
     mock_run = mocker.patch.object(app, "run")
     mock_run.side_effect = Exception("Stdio server error")
 
     with pytest.raises(Exception) as exc_info:
-        await main()
+        main()
     assert "Stdio server error" in str(exc_info.value)
 
 
-@pytest.mark.asyncio
-async def test_main_run_error(mocker: MockerFixture):
+def test_main_run_error(mocker: MockerFixture):
     """Test main function with app.run error."""
     mock_stdio = mocker.patch.object(stdio, "stdio_server")
     mock_context = mocker.MagicMock()
@@ -162,5 +192,5 @@ async def test_main_run_error(mocker: MockerFixture):
     mock_run.side_effect = Exception("App run error")
 
     with pytest.raises(Exception) as exc_info:
-        await main()
+        main()
     assert "App run error" in str(exc_info.value)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,8 +1,8 @@
 """Tests for the MCP Text Editor Server."""
 
 import json
+import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -36,8 +36,11 @@ def test_console_script_handles_initialize_request():
         },
     }
 
+    executable = shutil.which("mcp-text-editor")
+    assert executable is not None
+
     result = subprocess.run(
-        [str(Path(sys.executable).with_name("mcp-text-editor"))],
+        [executable],
         input=json.dumps(request) + "\n",
         text=True,
         capture_output=True,


### PR DESCRIPTION
## Summary

- call `FastMCP.run()` synchronously instead of nesting an event loop
- add a subprocess test that initializes the installed console script over stdio
- run the same canonical `mcp-text-editor` command from the Docker image

## Verification

- RED: console script exited with `RuntimeError: Already running asyncio in this thread`
- GREEN: `uv run pytest -q` — 169 passed
- `make check` — formatting, lint, and type checking passed
- real console script initialize — exit 0 with JSON-RPC response
- Docker build and initialize — exit 0 with JSON-RPC response

Closes #24
