### PR TITLE
fix: align MCP tool wrapper contracts

### DIFF
--- a/src/mcp_text_editor/server.py
+++ b/src/mcp_text_editor/server.py
@@ -1,7 +1,7 @@
 """MCP Text Editor Server implementation."""
 
 import logging
-from typing import List, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent, Tool
@@ -37,20 +37,17 @@ class GeminiCompatibleFastMCP(FastMCP):
         Returns:
             List of Tool objects with converted inputSchema.
         """
-        tools = await super().list_tools()
-
-        # Convert each tool's inputSchema to Gemini-compatible format
-        compatible_tools = []
-        for tool in tools:
-            compatible_schema = make_schema_gemini_compatible(tool.inputSchema)
-            compatible_tool = Tool(
-                name=tool.name,
-                description=tool.description,
-                inputSchema=compatible_schema,
+        await super().list_tools()
+        return [
+            Tool(
+                name=handler.name,
+                description=handler.description,
+                inputSchema=make_schema_gemini_compatible(
+                    handler.get_tool_description().inputSchema
+                ),
             )
-            compatible_tools.append(compatible_tool)
-
-        return compatible_tools
+            for handler in TOOL_HANDLERS
+        ]
 
 
 app = GeminiCompatibleFastMCP("mcp-text-editor")
@@ -62,47 +59,107 @@ create_file_handler = CreateTextFileHandler()
 append_file_handler = AppendTextFileContentsHandler()
 delete_contents_handler = DeleteTextFileContentsHandler()
 insert_file_handler = InsertTextFileContentsHandler()
+TOOL_HANDLERS = (
+    get_contents_handler,
+    patch_file_handler,
+    create_file_handler,
+    append_file_handler,
+    delete_contents_handler,
+    insert_file_handler,
+)
 
 
 # Register tools
 @app.tool()
-async def get_text_file_contents(path: str) -> Sequence[TextContent]:
-    """Get the contents of a text file."""
-    return await get_contents_handler.run_tool({"path": path})
+async def get_text_file_contents(
+    files: List[Dict[str, Any]], encoding: str = "utf-8"
+) -> Sequence[TextContent]:
+    """Get the contents of text files."""
+    return await get_contents_handler.run_tool({"files": files, "encoding": encoding})
 
 
 @app.tool()
-async def patch_text_file_contents(path: str, content: str) -> Sequence[TextContent]:
+async def patch_text_file_contents(
+    file_path: str,
+    file_hash: str,
+    patches: List[Dict[str, Any]],
+    encoding: str = "utf-8",
+) -> Sequence[TextContent]:
     """Patch the contents of a text file."""
-    return await patch_file_handler.run_tool({"path": path, "content": content})
+    return await patch_file_handler.run_tool(
+        {
+            "file_path": file_path,
+            "file_hash": file_hash,
+            "patches": patches,
+            "encoding": encoding,
+        }
+    )
 
 
 @app.tool()
-async def create_text_file(path: str) -> Sequence[TextContent]:
+async def create_text_file(
+    file_path: str, contents: str, encoding: str = "utf-8"
+) -> Sequence[TextContent]:
     """Create a new text file."""
-    return await create_file_handler.run_tool({"path": path})
+    return await create_file_handler.run_tool(
+        {"file_path": file_path, "contents": contents, "encoding": encoding}
+    )
 
 
 @app.tool()
-async def append_text_file_contents(path: str, content: str) -> Sequence[TextContent]:
+async def append_text_file_contents(
+    file_path: str, file_hash: str, contents: str, encoding: str = "utf-8"
+) -> Sequence[TextContent]:
     """Append content to a text file."""
-    return await append_file_handler.run_tool({"path": path, "content": content})
+    return await append_file_handler.run_tool(
+        {
+            "file_path": file_path,
+            "file_hash": file_hash,
+            "contents": contents,
+            "encoding": encoding,
+        }
+    )
 
 
 @app.tool()
-async def delete_text_file_contents(path: str) -> Sequence[TextContent]:
+async def delete_text_file_contents(
+    file_path: str,
+    file_hash: str,
+    ranges: List[Dict[str, Any]],
+    encoding: str = "utf-8",
+) -> Sequence[TextContent]:
     """Delete the contents of a text file."""
-    return await delete_contents_handler.run_tool({"path": path})
+    return await delete_contents_handler.run_tool(
+        {
+            "file_path": file_path,
+            "file_hash": file_hash,
+            "ranges": ranges,
+            "encoding": encoding,
+        }
+    )
 
 
 @app.tool()
 async def insert_text_file_contents(
-    path: str, content: str, position: int
+    file_path: str,
+    file_hash: str,
+    contents: str,
+    before: Optional[int] = None,
+    after: Optional[int] = None,
+    encoding: str = "utf-8",
 ) -> Sequence[TextContent]:
     """Insert content into a text file at a specific position."""
-    return await insert_file_handler.run_tool(
-        {"path": path, "content": content, "position": position}
-    )
+    arguments: Dict[str, Any] = {
+        "file_path": file_path,
+        "file_hash": file_hash,
+        "contents": contents,
+        "encoding": encoding,
+    }
+    if before is not None:
+        arguments["before"] = before
+    if after is not None:
+        arguments["after"] = after
+    return await insert_file_handler.run_tool(arguments)
 
 
 async def main() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,6 +7,7 @@ from mcp.server import stdio
 from mcp.types import TextContent
 from pytest_mock import MockerFixture
 
+from mcp_text_editor.schema_compat import make_schema_gemini_compatible
 from mcp_text_editor.server import (
     app,
     append_file_handler,
@@ -19,10 +20,113 @@ from mcp_text_editor.server import (
 )
 from mcp_text_editor.text_editor import TextEditor
 
+HANDLERS = (
+    get_contents_handler,
+    patch_file_handler,
+    create_file_handler,
+    append_file_handler,
+    delete_contents_handler,
+    insert_file_handler,
+)
+
 
 @pytest.fixture
 def editor():
     return TextEditor()
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_tools_match_handler_schemas():
+    tools = {tool.name: tool for tool in await app.list_tools()}
+
+    assert set(tools) == {handler.name for handler in HANDLERS}
+    for handler in HANDLERS:
+        expected = handler.get_tool_description()
+        actual = tools[handler.name]
+        assert actual.inputSchema == make_schema_gemini_compatible(expected.inputSchema)
+        assert actual.description == expected.description
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_tools_accept_handler_arguments(tmp_path, editor):
+    def file_hash(path: Path) -> str:
+        return editor.calculate_hash(path.read_text())
+
+    read_file = tmp_path / "read.txt"
+    read_file.write_text("read\n")
+    patch_file = tmp_path / "patch.txt"
+    patch_file.write_text("old\n")
+    append_file = tmp_path / "append.txt"
+    append_file.write_text("first\n")
+    delete_file = tmp_path / "delete.txt"
+    delete_file.write_text("remove\n")
+    insert_file = tmp_path / "insert.txt"
+    insert_file.write_text("first\nsecond\n")
+    new_file = tmp_path / "new.txt"
+
+    calls = (
+        (
+            "get_text_file_contents",
+            {"files": [{"file_path": str(read_file), "ranges": [{"start": 1}]}]},
+        ),
+        (
+            "patch_text_file_contents",
+            {
+                "file_path": str(patch_file),
+                "file_hash": file_hash(patch_file),
+                "patches": [
+                    {
+                        "start": 1,
+                        "end": 1,
+                        "contents": "new\n",
+                        "range_hash": file_hash(patch_file),
+                    }
+                ],
+            },
+        ),
+        (
+            "create_text_file",
+            {"file_path": str(new_file), "contents": "created\n"},
+        ),
+        (
+            "append_text_file_contents",
+            {
+                "file_path": str(append_file),
+                "file_hash": file_hash(append_file),
+                "contents": "second\n",
+            },
+        ),
+        (
+            "delete_text_file_contents",
+            {
+                "file_path": str(delete_file),
+                "file_hash": file_hash(delete_file),
+                "ranges": [
+                    {"start": 1, "end": 1, "range_hash": file_hash(delete_file)}
+                ],
+            },
+        ),
+        (
+            "insert_text_file_contents",
+            {
+                "file_path": str(insert_file),
+                "file_hash": file_hash(insert_file),
+                "contents": "inserted\n",
+                "before": 2,
+            },
+        ),
+    )
+
+    for name, arguments in calls:
+        result = await app._tool_manager.call_tool(name, arguments)
+        assert len(result) == 1
+        assert isinstance(result[0], TextContent)
+
+    assert patch_file.read_text() == "new\n"
+    assert new_file.read_text() == "created\n"
+    assert append_file.read_text() == "first\nsecond\n"
+    assert delete_file.read_text() == ""
+    assert insert_file.read_text() == "first\ninserted\nsecond\n"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- align all six FastMCP wrappers with their handler argument contracts
- use each handler's tool description as the advertised schema source
- verify every tool schema and real call through the FastMCP tool manager

## Verification

- RED: schemas differed and handler-shaped calls failed at the wrapper boundary
- GREEN: `uv run pytest -q` — 170 passed
- `make check` — formatting, lint, and type checking passed

Closes #23
