### PR TITLE
fix: reject empty patch batches

### DIFF
--- a/src/mcp_text_editor/text_editor.py
+++ b/src/mcp_text_editor/text_editor.py
@@ -429,14 +429,13 @@ class TextEditor:
                 else:
                     contents = patch["contents"]
 
-                # Check if this is a deletion (empty content)
-                if not contents.strip():
-                    return {
-                        "result": "ok",
-                        "file_hash": current_file_hash,  # Return current hash since no changes made
-                        "hint": "For content deletion, please consider using delete_text_file_contents instead of patch with empty content",
-                        "suggestion": "delete",
-                    }
+                # Empty replacements are ambiguous; reject the entire atomic batch.
+                if contents == "":
+                    return self.create_error_response(
+                        "Empty patch contents are not supported",
+                        suggestion="delete",
+                        hint="Please use delete_text_file_contents to delete content",
+                    )
 
                 # Set suggestions for alternative tools
                 suggestion_text: Optional[str] = None

--- a/tests/test_error_hints.py
+++ b/tests/test_error_hints.py
@@ -121,7 +121,8 @@ async def test_empty_content_delete_hint(editor, tmp_path):
         ],
     )
 
-    assert result["result"] == "ok"  # Note: It's "ok" but suggests using delete
+    assert result["result"] == "error"
+    assert "empty" in result["reason"].lower()
     assert result["suggestion"] == "delete"
     assert "delete_text_file_contents" in result["hint"]
 

--- a/tests/test_patch_text_file.py
+++ b/tests/test_patch_text_file.py
@@ -88,9 +88,9 @@ async def test_patch_text_file_empty_content(tmp_path):
         [patch],
     )
 
-    # Verify that the operation suggests using delete_text_file_contents
-    assert result["result"] == "ok"
-    assert result["file_hash"] == file_hash
+    # Verify that the operation rejects the ambiguous no-op as an error
+    assert result["result"] == "error"
+    assert "empty" in result["reason"].lower()
     assert "delete_text_file_contents" in result["hint"]
     assert result["suggestion"] == "delete"
 

--- a/tests/test_text_editor.py
+++ b/tests/test_text_editor.py
@@ -849,6 +849,61 @@ async def test_edit_file_without_end(editor, tmp_path):
     assert test_file.read_text() == "new line\nline2\nline3\n"
 
 
+@pytest.mark.asyncio
+async def test_empty_patch_rejects_entire_batch(editor: TextEditor, tmp_path):
+    """Reject empty replacements without discarding batch changes as success."""
+    test_file = tmp_path / "test.txt"
+    original_content = "line1\nline2\nline3\n"
+    test_file.write_text(original_content)
+
+    result = await editor.edit_file_contents(
+        str(test_file),
+        editor.calculate_hash(original_content),
+        [
+            {
+                "start": 3,
+                "end": 3,
+                "contents": "updated\n",
+                "range_hash": editor.calculate_hash("line3\n"),
+            },
+            {
+                "start": 1,
+                "end": 1,
+                "contents": "",
+                "range_hash": editor.calculate_hash("line1\n"),
+            },
+        ],
+    )
+
+    assert result["result"] == "error"
+    assert "empty" in result["reason"].lower()
+    assert test_file.read_text() == original_content
+
+
+@pytest.mark.asyncio
+async def test_whitespace_patch_is_not_treated_as_empty(editor: TextEditor, tmp_path):
+    """Preserve intentional whitespace-only replacement content."""
+    test_file = tmp_path / "test.txt"
+    original_content = "line1\nline2\n"
+    test_file.write_text(original_content)
+
+    result = await editor.edit_file_contents(
+        str(test_file),
+        editor.calculate_hash(original_content),
+        [
+            {
+                "start": 1,
+                "end": 1,
+                "contents": "   ",
+                "range_hash": editor.calculate_hash("line1\n"),
+            }
+        ],
+    )
+
+    assert result["result"] == "ok"
+    assert test_file.read_text() == "   \nline2\n"
+
+
 def test_validate_environment():
     """Test environment validation."""
     # Currently _validate_environment is a placeholder


### PR DESCRIPTION
## Summary

- reject empty patch contents with an explicit error instead of returning a false success
- preserve batch atomicity when an empty patch is mixed with valid patches
- allow whitespace-only replacement content instead of treating it as empty

## Verification

- `uv run pytest -q` — 170 passed
- `make check` — formatting, lint, and type checking passed

Closes #25
