### PR TITLE
fix: report package server version

### DIFF
--- a/src/mcp_text_editor/server.py
+++ b/src/mcp_text_editor/server.py
@@ -54,6 +54,8 @@ class GeminiCompatibleFastMCP(FastMCP):
 
 
 app = GeminiCompatibleFastMCP("mcp-text-editor")
+# FastMCP 1.25.0 does not expose a version constructor argument.
+app._mcp_server.version = __version__
 
 # Initialize handlers
 get_contents_handler = GetTextFileContentsHandler()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,11 +18,19 @@ from mcp_text_editor.server import (
     patch_file_handler,
 )
 from mcp_text_editor.text_editor import TextEditor
+from mcp_text_editor.version import __version__
 
 
 @pytest.fixture
 def editor():
     return TextEditor()
+
+
+def test_initialization_options_report_project_version():
+    """Report the mcp-text-editor version instead of the SDK version."""
+    options = app._mcp_server.create_initialization_options()
+
+    assert options.server_version == __version__
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- set the wrapped MCP server version to the package's `__version__`
- verify initialization options report the mcp-text-editor version instead of the installed MCP SDK version

## Verification

- `uv run pytest -q` — 169 passed
- `make check` — formatting, lint, and type checking passed

Closes #27
