### PR TITLE
fix: bound MCP dependency to compatible major

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "tumf" }
 ]
 dependencies = [
-    "mcp>=1.25.0",
+    "mcp>=1.25.0,<2",
     "chardet>=5.2.0",
     "portalocker>=3.2.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -493,7 +493,7 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.0.0" },
     { name = "chardet", specifier = ">=5.2.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "mcp", specifier = ">=1.25.0" },
+    { name = "mcp", specifier = ">=1.25.0,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.0" },
     { name = "portalocker", specifier = ">=3.2.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.0" },


### PR DESCRIPTION
## Summary

- constrain the MCP dependency to the compatible 1.x API line
- keep the lockfile aligned with the declared production dependency
- prevent fresh installs from resolving MCP 2.x, whose API and type surface are incompatible with this release

## Verification

- `uv lock`
- `uv sync --all-extras --frozen`
- installed MCP version — 1.25.0
- `uv run pytest -q` — 168 passed
- `make check` — formatting, lint, and type checking passed

The existing implementation and current repair PRs target MCP 1.25.x. MCP 2.x support should be handled as a separate migration rather than an implicit dependency upgrade.
