### PR TITLE
fix: reject empty patch lists

### DIFF
--- a/src/mcp_text_editor/text_editor.py
+++ b/src/mcp_text_editor/text_editor.py
@@ -254,6 +254,13 @@ class TextEditor:
         """
         self._validate_file_path(file_path)
         try:
+            if not patches:
+                return self.create_error_response(
+                    "Empty patch batch: no patches to apply",
+                    suggestion="get",
+                    hint="Please provide at least one patch",
+                )
+
             # Reject unknown mapping fields before creating directories or touching files.
             allowed_patch_fields = set(EditPatch.model_fields)
             for raw_patch in patches:

--- a/tests/test_text_editor.py
+++ b/tests/test_text_editor.py
@@ -896,6 +896,23 @@ async def test_empty_patch_rejects_entire_batch(editor: TextEditor, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_empty_patch_batch_is_rejected(editor: TextEditor, tmp_path):
+    """Reject a batch with no patches using an actionable error."""
+    test_file = tmp_path / "test.txt"
+    original_content = "line1\nline2\nline3\n"
+    test_file.write_text(original_content)
+
+    result = await editor.edit_file_contents(
+        str(test_file), editor.calculate_hash(original_content), []
+    )
+
+    assert result["result"] == "error"
+    assert result["reason"] == "Empty patch batch: no patches to apply"
+    assert result["suggestion"] == "get"
+    assert test_file.read_text() == original_content
+
+
+@pytest.mark.asyncio
 async def test_whitespace_patch_is_not_treated_as_empty(editor: TextEditor, tmp_path):
     """Preserve intentional whitespace-only replacement content."""
     test_file = tmp_path / "test.txt"


### PR DESCRIPTION
## Summary

- reject an empty `patches` list before any file operation
- return an actionable error instead of leaking `UnboundLocalError`
- preserve the target file unchanged
- add regression coverage for the empty-batch contract

## Verification

- `make all`
- 176 tests passed
- coverage: 93%

Fixes #39
